### PR TITLE
feat: 0.2.0 Improved regex, use match instead of split on =, avoid warning on single quote escaping

### DIFF
--- a/src/core.awk
+++ b/src/core.awk
@@ -33,10 +33,10 @@
     lt_rgx = time_rgx
     datetime_rgx = "(" odt_rgx "|" ldt_rgx "|" ld_rgx "|" lt_rgx ")"
     var_lhs_rgx = "(\" *[^-}#\\]\\[=" banned ban_slash "]+ *\"|[^-}#\\]\\[=" banned ban_slash "]+)"
-    var_rhs_rgx = "(\" *[^}\\]\\[" banned "]+ *\"|true|false|" int_rgx "|" float_rgx "|" datetime_rgx ")"
+    var_rhs_rgx = "(\" *[^}\\]\\[" banned "]* *\"|true|false|" int_rgx "|" float_rgx "|" datetime_rgx ")"
     var_rgx = "^" var_lhs_rgx " *= *" var_rhs_rgx "$"
     struct_rgx = "^" var_lhs_rgx " *= *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* *\\}$"
-    arr_val_rgx = " *((\" *[^}\\]\\[," banned "]+ *\" *)(, *\" *[^}\\]\\[," banned "]+ *\" *)*|( *(true|false) *)(, *(true|false) *)*|( *" int_rgx " *)(, *" int_rgx " *)*|( *" float_rgx " *)(, *" float_rgx " *)*|( *" datetime_rgx " *)(, *" datetime_rgx " *)*) *,? *"
+    arr_val_rgx = " *((\" *[^}\\]\\[," banned "]* *\" *)(, *\" *[^}\\]\\[," banned "]* *\" *)*|( *(true|false) *)(, *(true|false) *)*|( *" int_rgx " *)(, *" int_rgx " *)*|( *" float_rgx " *)(, *" float_rgx " *)*|( *" datetime_rgx " *)(, *" datetime_rgx " *)*) *,? *"
     arr_rgx = "^" var_lhs_rgx " *= *\\[" arr_val_rgx "\\]$"
     struct_arr_rgx = "^" var_lhs_rgx " *= *\\{ *(" var_lhs_rgx " *= *\\[" arr_val_rgx "\\] *)(, *" var_lhs_rgx " *= *\\[" arr_val_rgx "\\] *)* *\\}$"
     arr_struct_rgx = "^" var_lhs_rgx " *= *\\[ *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* \\} *(, *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* \\})* *,? *\\]$"
@@ -58,7 +58,7 @@
         # Check if the line is a valid variable assignment
 
         variable = gensub(/^ *"?([^="]+)"? *=.*$/, "\\1", "g", $0)
-        value = gensub(/^.*= *"?([^"]+)"? *$/, "\\1", "g", $0)
+        value = gensub(/^.*= *"?([^"]*)"? *$/, "\\1", "g", $0)
 
         # Replace dashes with underscores
         gsub(/[-]/, "_", variable)
@@ -131,14 +131,12 @@
             arr_idx=0;
             split(arrval, arr_tokens, ",");
             for (arr_value in arr_tokens) {
-                val = gensub(/^ *"([^"=,\\\]]+)" *$/, "\\1", "g", arr_tokens[arr_value])
-                if (val != "") {
-                    struct_array_values[current_scope "_" variable "_" arrname "[" arr_idx "]" ]=val
-                    if (!(current_scope in scopes)) {
-                        scopes[current_scope]++
-                    }
-                    arr_idx++
+                val = gensub(/^ *"([^"=,\\\]]*)" *$/, "\\1", "g", arr_tokens[arr_value])
+                struct_array_values[current_scope "_" variable "_" arrname "[" arr_idx "]" ]=val
+                if (!(current_scope in scopes)) {
+                    scopes[current_scope]++
                 }
+                arr_idx++
             }
             if (arr_idx > 0) {
                 struct_array_names[current_scope "_" variable "_" arrname ]=arrname
@@ -298,14 +296,12 @@
         arr_idx=0;
         split(value, arr_tokens, ",");
         for (arr_value in arr_tokens) {
-            val = gensub(/^ *"([^",\\\]]+)" *$/, "\\1", "g", arr_tokens[arr_value])
-            if (val != "") {
-                array_values[current_scope "_" variable "[" arr_idx "]" ]=val
-                if (!(current_scope in scopes)) {
-                    scopes[current_scope]++
-                }
-                arr_idx++
+            val = gensub(/^ *"([^",\\\]]*)" *$/, "\\1", "g", arr_tokens[arr_value])
+            array_values[current_scope "_" variable "[" arr_idx "]" ]=val
+            if (!(current_scope in scopes)) {
+                scopes[current_scope]++
             }
+            arr_idx++
         }
         if (arr_idx > 0) {
             array_names[current_scope "_" variable ]=variable

--- a/tests/arrays.stego
+++ b/tests/arrays.stego
@@ -1,7 +1,7 @@
 ints    = [1, 2, 3, 4]
 floats  = [0.1, 1.5, -2.0]
 bools   = [true, false, true]
-strings = ["a", "b", "c"]
+strings = ["a", "b", "c", ""]
 dates   = [1979-05-27, 2024-11-01]
 times   = [07:32:00, 23:59:59]
 

--- a/tests/atomics.stego
+++ b/tests/atomics.stego
@@ -14,6 +14,7 @@ flag_false = false
 
 str_space  = "hello world"
 str_symbol = ">=0.3"
+str_empty = ""
 
 dt_offset_utc = 1979-05-27T07:32:00Z
 dt_offset     = 1979-05-27T00:32:00-07:00

--- a/tests/structs.stego
+++ b/tests/structs.stego
@@ -1,4 +1,4 @@
-server = { host = "localhost", port = 8080, enabled = true }
+server = { host = "localhost", port = 8080, enabled = true, name = "" }
 limits = { min = 0.1, max = 1.0 }
 window = { width = 800, height = 600 }
 


### PR DESCRIPTION
### Added

- Add regexes for intermediate parts
- Add support for quoted string, `int`, `float`, `bool`, `datetime` rhs values
- Add support for `A-Z` in splitting variable name in struct_arr
- Add support for `""` in rhs values

### Changed

- Drop support for unquoted rhs values
- Drop support for `=` in lhs values
- Drop support for `=` in scopes
- Use `match` instead of `split` on `=`
  - Closes #3 
- Use `\047` to express `'` avoiding warning from escaping and still allowing `bash` internalisation