### PR TITLE
feat: 0.3.0 Allow structs with mixed values, arrays of structs can hold inner arrays

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,67 @@
 # akcipitro
 
 Lex "scopes", "variables", "values" from a stego file.
+
+Used by [amboso](https://github.com/jgabaut/amboso) to parse its stego files.
+
+The format is a restricted `TOML`.
+
+Currently supported values:
+
+- Plain
+- Arrays (not nested directly)
+- Structs (not nested)
+- Arrays of structs (with above limitations)
+
+```toml
+foo = "abc"
+bar = 123
+baz = 10.5
+[ my_scope ]
+bog = [ "foo", "bar" ]
+bor = [ 123, 124 ]
+boz = [ 10.5, 1.5 ]
+car = { foo = "123", bar = 124, baz = [ "foo", "bar" ], bog = [ 123, 124 ] }
+coz = [ { foo = 123, bar = "abc" }, { foo = [ 123, 124 ] } ]
+```
+
+Output:
+
+```console
+Scope:
+Variable: _foo, Value: abc
+Variable: _baz, Value: 10.5
+Variable: _bar, Value: 123
+------------------------
+Scope: my_scope
+Array: my_scope_bor, Name: bor
+Arrvalue: my_scope_bor[0], Value: 123
+Arrvalue: my_scope_bor[1], Value:  124
+Array: my_scope_bog, Name: bog
+Arrvalue: my_scope_bog[0], Value: foo
+Arrvalue: my_scope_bog[1], Value: bar
+Array: my_scope_boz, Name: boz
+Arrvalue: my_scope_boz[0], Value: 10.5
+Arrvalue: my_scope_boz[1], Value:  1.5
+Struct: my_scope_car, Name: car
+Structvalue: my_scope_car_bar, Value: 124
+Structvalue: my_scope_car_foo, Value: 123
+In-Struct Array: my_scope_car_bog, Name: bog
+In-Struct Array: my_scope_car_baz, Name: baz
+In-Struct Arrvalue: my_scope_car_baz[0], Value: foo
+In-Struct Arrvalue: my_scope_car_baz[1], Value: bar
+In-Struct Arrvalue: my_scope_car_bog[0], Value:  123
+In-Struct Arrvalue: my_scope_car_bog[1], Value:  124
+In-Arr Struct: my_scope_coz_0, Name: coz
+In-Arr Struct: my_scope_coz_1, Name: coz
+In-Arr Structvalue: my_scope_coz_1[foo_0], Value:  123
+In-Arr Structvalue: my_scope_coz_0[bar], Value: abc
+In-Arr Structvalue: my_scope_coz_1[foo_1], Value:  124
+In-Arr Structvalue: my_scope_coz_0[foo], Value: 123
+In-Arr Struct Array: my_scope_coz_1_foo, Name: foo, Len: 2
+------------------------
+```
+
 For each error detected in the file, prints a notice to stderr.
 If any error is detected, it returns before printing to stdout.
 Otherwise, prints the parsed tokens to stdout, using this format:

--- a/src/core.awk
+++ b/src/core.awk
@@ -72,7 +72,6 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
     arr_val_rgx = " *((\" *[^}\\]\\[," banned "]* *\" *)(, *\" *[^}\\]\\[," banned "]* *\" *)*|( *(true|false) *)(, *(true|false) *)*|( *" int_rgx " *)(, *" int_rgx " *)*|( *" float_rgx " *)(, *" float_rgx " *)*|( *" datetime_rgx " *)(, *" datetime_rgx " *)*) *,? *"
     arr_rgx = "^" var_lhs_rgx " *= *\\[" arr_val_rgx "\\]$"
     struct_rgx = "^" var_lhs_rgx " *= *\\{ *(" var_lhs_rgx " *= *(" var_rhs_rgx "|\\[" arr_val_rgx "\\]) *)(, *" var_lhs_rgx " *= *(" var_rhs_rgx "|\\[" arr_val_rgx "\\]) *)* *\\}$"
-    struct_arr_rgx = "^" var_lhs_rgx " *= *\\{ *(" var_lhs_rgx " *= *\\[" arr_val_rgx "\\] *)(, *" var_lhs_rgx " *= *\\[" arr_val_rgx "\\] *)* *\\}$"
     arr_struct_rgx = "^" var_lhs_rgx " *= *\\[ *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* \\} *(, *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* \\})* *,? *\\]$"
 
     if ($0 ~ scope_rgx) {
@@ -115,70 +114,6 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
         if (!(current_scope in scopes)) {
             scopes[current_scope]++
         }
-    } else if ($0 ~ struct_arr_rgx) {
-        # Check if line has a curly bracket array rightval
-        # Extract variable
-        variable = gensub(/^ *"?([^{="]+)"? *=.*$/, "\\1", "g", $0)
-        value = gensub(/^.*= *{ *([^}]+) *}$/, "\\1", "g", $0)
-        # Replace dashes with underscores
-        gsub(/[-]/, "_", variable)
-        # Trim trailing whitespaces from variable and value
-        gsub(/[ \t]+$/, "", variable)
-        gsub(/[ \t]+$/, "", value)
-
-        # Check if left side contains disallowed characters
-        if (index(variable, " ") > 0 || (index(variable, "#") > 0 && index(variable, "\"") == 0)) {
-            print "[LINT]    Invalid left side (contains spaces or disallowed characters):    " variable "" > "/dev/stderr"
-            error_flag=1
-            next
-        }
-
-        if (current_scope == "main") {
-            variable = "main_" variable
-        }
-
-        #struct_values[current_scope "_" variable]=value
-        #struct_names[current_scope "_" variable ]=variable
-
-        while (match(value, /^ *,? *"?([^\\\$#\]\["]+)"? *= *\[ *([^\\\$#\]\[]+) *\] */, parts)) {
-            # Trim trailing whitespaces from variable and value
-            gsub(/[ \t]+$/, "", parts[0])
-            gsub(/[ \t]+$/, "", parts[1])
-            # Trim leading whitespaces from variable and value
-            gsub(/^[ \t]+/, "", parts[0])
-            gsub(/^[ \t]+/, "", parts[1])
-            #print "[LINT]    Parts[0]: { " parts[0] " }"
-            #print "[LINT]    Parts[1]: { " parts[1] " }"
-            # Extract val
-            arrname = parts[1]
-            arrval = gensub(/^.*= *\[ *([^\[\\\$]+) *\]$/, "\\1", "g", parts[0])
-
-            # Replace dashes with underscores
-            gsub(/[-]/, "_", arrname)
-            # Trim trailing whitespaces from arrname, arrval
-            gsub(/[ \t]+$/, "", arrname)
-            gsub(/[ \t]+$/, "", arrval)
-
-            #print "[LINT]    Arrname: { " arrname " }"
-            #print "[LINT]    Arrval: { " arrval " }"
-
-            arr_idx=0;
-            split(arrval, arr_tokens, ",");
-            for (arr_value in arr_tokens) {
-                val = gensub(/^ *"([^"=,\\\]]*)" *$/, "\\1", "g", arr_tokens[arr_value])
-                struct_array_values[current_scope "_" variable "_" arrname "[" arr_idx "]" ]=val
-                if (!(current_scope in scopes)) {
-                    scopes[current_scope]++
-                }
-                arr_idx++
-            }
-            if (arr_idx > 0) {
-                struct_array_names[current_scope "_" variable "_" arrname ]=arrname
-            }
-
-            sub(/^[^\]A-Z\\\$#\]\[]+ *= *\[ *[^\]A-Z\\\$#\]\[]+ *\] *,?/,"",value)
-        }
-
     } else if ($0 ~ struct_rgx) {
         # Check if line has a curly bracket rightval
         # Extract variable

--- a/src/core.awk
+++ b/src/core.awk
@@ -1,4 +1,38 @@
 #!/usr/bin/awk -f
+function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
+    n = 0
+    buf = ""
+    depth_sq = depth_cu = 0
+    in_str = 0
+
+    for (i = 1; i <= length(s); i++) {
+        c = substr(s, i, 1)
+
+        if (c == "\"" && substr(s, i-1, 1) != "\\")
+            in_str = !in_str
+
+        if (!in_str) {
+            if (c == "[") depth_sq++
+            else if (c == "]") depth_sq--
+            else if (c == "{") depth_cu++
+            else if (c == "}") depth_cu--
+        }
+
+        if (c == "," && !in_str && depth_sq == 0 && depth_cu == 0) {
+            out[++n] = buf
+            buf = ""
+            continue
+        }
+
+        buf = buf c
+    }
+
+    if (buf != "")
+        out[++n] = buf
+
+    return n
+}
+
 {
     # Remove leading and trailing whitespaces
     gsub(/^[ \t]+|[ \t]+$/, "")
@@ -35,9 +69,9 @@
     var_lhs_rgx = "(\" *[^-}#\\]\\[=" banned ban_slash "]+ *\"|[^-}#\\]\\[=" banned ban_slash "]+)"
     var_rhs_rgx = "(\" *[^}\\]\\[" banned "]* *\"|true|false|" int_rgx "|" float_rgx "|" datetime_rgx ")"
     var_rgx = "^" var_lhs_rgx " *= *" var_rhs_rgx "$"
-    struct_rgx = "^" var_lhs_rgx " *= *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* *\\}$"
     arr_val_rgx = " *((\" *[^}\\]\\[," banned "]* *\" *)(, *\" *[^}\\]\\[," banned "]* *\" *)*|( *(true|false) *)(, *(true|false) *)*|( *" int_rgx " *)(, *" int_rgx " *)*|( *" float_rgx " *)(, *" float_rgx " *)*|( *" datetime_rgx " *)(, *" datetime_rgx " *)*) *,? *"
     arr_rgx = "^" var_lhs_rgx " *= *\\[" arr_val_rgx "\\]$"
+    struct_rgx = "^" var_lhs_rgx " *= *\\{ *(" var_lhs_rgx " *= *(" var_rhs_rgx "|\\[" arr_val_rgx "\\]) *)(, *" var_lhs_rgx " *= *(" var_rhs_rgx "|\\[" arr_val_rgx "\\]) *)* *\\}$"
     struct_arr_rgx = "^" var_lhs_rgx " *= *\\{ *(" var_lhs_rgx " *= *\\[" arr_val_rgx "\\] *)(, *" var_lhs_rgx " *= *\\[" arr_val_rgx "\\] *)* *\\}$"
     arr_struct_rgx = "^" var_lhs_rgx " *= *\\[ *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* \\} *(, *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* \\})* *,? *\\]$"
 
@@ -164,28 +198,46 @@
         if (current_scope == "main") {
             variable = "main_" variable
         }
-        split(value, struct_tokens, ",");
+        #split(value, struct_tokens, ",");
+        delete struct_tokens
+        n = split_top_level(value, struct_tokens)
         for (struct_decl in struct_tokens) {
             if (match(struct_tokens[struct_decl], /^[[:space:]]*([^=[:space:]]+)[[:space:]]*=[[:space:]]*(.*)$/, m)) {
                 var = m[1]
                 val = m[2]
 
                 var=gensub(/^ *"?([^"]+)"? *$/, "\\1", "g", var)
-                val=gensub(/^ *"?([^"]*)"? *$/, "\\1", "g", val)
-                # Trim trailing whitespaces from variable and value
-                gsub(/[ \t]+$/, "", var)
-                gsub(/[ \t]+$/, "", val)
+                if(match(val, " *\\[(" arr_val_rgx ")\\] *$", m2)) {
+                    arr_idx=0;
+                    split(m2[1], arr_tokens, ",");
+                    for (arr_value in arr_tokens) {
+                        m2[1] = gensub(/^ *"([^"=,\\\]]*)" *$/, "\\1", "g", arr_tokens[arr_value])
+                        struct_array_values[current_scope "_" variable "_" var "[" arr_idx "]" ]=m2[1]
+                        if (!(current_scope in scopes)) {
+                            scopes[current_scope]++
+                        }
+                        arr_idx++
+                    }
+                    if (arr_idx > 0) {
+                        struct_array_names[current_scope "_" variable "_" var ]=var
+                    }
+                } else {
+                    val=gensub(/^ *"?([^"]*)"? *$/, "\\1", "g", val)
+                    # Trim trailing whitespaces from variable and value
+                    gsub(/[ \t]+$/, "", var)
+                    gsub(/[ \t]+$/, "", val)
 
-                # Check if left side contains disallowed characters
-                if (index(var, " ") > 0 || (index(var, "#") > 0 && index(var, "\"") == 0)) {
-                    print "[LINT]    Invalid left side (contains spaces or disallowed characters):    " var "" > "/dev/stderr"
-                    error_flag=1
-                    next
+                    # Check if left side contains disallowed characters
+                    if (index(var, " ") > 0 || (index(var, "#") > 0 && index(var, "\"") == 0)) {
+                        print "[LINT]    Invalid left side (contains spaces or disallowed characters):    " var "" > "/dev/stderr"
+                        error_flag=1
+                        next
+                    }
+                    if (!(current_scope in scopes)) {
+                        scopes[current_scope]++
+                    }
+                    struct_values[current_scope "_" variable "_" var]=val
                 }
-                if (!(current_scope in scopes)) {
-                    scopes[current_scope]++
-                }
-                struct_values[current_scope "_" variable "_" var]=val
             } else {
                 print "[LEX]    Failed capture of struct_decl " struct_tokens[struct_decl] "" > "/dev/stderr"
                 error_flag=1

--- a/src/core.awk
+++ b/src/core.awk
@@ -193,8 +193,8 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
         # Extract variable
         variable = gensub(/^ *"?([^\{\[="]+)"? *=.*$/, "\\1", "g", $0)
         value = $0
-        sub(/^[^[]*\[/, "", value)   # remove up to first '['
-        sub(/\][^]]*$/, "", value)   # remove from last ']'
+        sub(/^[^[]*\[/, "", value)   # remove up to first [
+        sub(/\][^]]*$/, "", value)   # remove from last ]
 
         # Replace dashes with underscores
         gsub(/[-]/, "_", variable)

--- a/src/core.awk
+++ b/src/core.awk
@@ -45,6 +45,11 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
         next
     }
 
+    if ($0 ~ "<\\(") {
+        print "[LINT]    Command substitution detected:    " $0 "" > "/dev/stderr"
+        error_flag=1
+        next
+    }
 
     banned = "$\"\047\\\\"
     ban_slash = "\\/"
@@ -87,6 +92,7 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
         } else {
             print "[LINT]    Invalid header:    " $0 "" > "/dev/stderr"
             error_flag=1
+            next
         }
     } else if ($0 ~ var_rgx) {
         # Check if the line is a valid variable assignment

--- a/src/core.awk
+++ b/src/core.awk
@@ -71,8 +71,9 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
     var_rgx = "^" var_lhs_rgx " *= *" var_rhs_rgx "$"
     arr_val_rgx = " *((\" *[^}\\]\\[," banned "]* *\" *)(, *\" *[^}\\]\\[," banned "]* *\" *)*|( *(true|false) *)(, *(true|false) *)*|( *" int_rgx " *)(, *" int_rgx " *)*|( *" float_rgx " *)(, *" float_rgx " *)*|( *" datetime_rgx " *)(, *" datetime_rgx " *)*) *,? *"
     arr_rgx = "^" var_lhs_rgx " *= *\\[" arr_val_rgx "\\]$"
-    struct_rgx = "^" var_lhs_rgx " *= *\\{ *(" var_lhs_rgx " *= *(" var_rhs_rgx "|\\[" arr_val_rgx "\\]) *)(, *" var_lhs_rgx " *= *(" var_rhs_rgx "|\\[" arr_val_rgx "\\]) *)* *\\}$"
-    arr_struct_rgx = "^" var_lhs_rgx " *= *\\[ *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* \\} *(, *\\{ *(" var_lhs_rgx " *= *" var_rhs_rgx " *)(, *" var_lhs_rgx " *= *" var_rhs_rgx " *)* \\})* *,? *\\]$"
+    struct_val_rgx = " *(" var_lhs_rgx " *= *(" var_rhs_rgx "|\\[" arr_val_rgx "\\]) *)(, *" var_lhs_rgx " *= *(" var_rhs_rgx "|\\[" arr_val_rgx "\\]) *)* *"
+    struct_rgx = "^" var_lhs_rgx " *= *\\{" struct_val_rgx "\\}$"
+    arr_struct_rgx = "^" var_lhs_rgx " *= *\\[ *\\{" struct_val_rgx "\\} *(, *\\{" struct_val_rgx "\\})* *,? *\\]$"
 
     if ($0 ~ scope_rgx) {
         # Extract and set the current scope
@@ -185,7 +186,10 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
 
         # Extract variable
         variable = gensub(/^ *"?([^\{\[="]+)"? *=.*$/, "\\1", "g", $0)
-        value = gensub(/^.*= *\[ *([^\]]+) *\] *$/, "\\1", "g", $0)
+        value = $0
+        sub(/^[^[]*\[/, "", value)   # remove up to first '['
+        sub(/\][^]]*$/, "", value)   # remove from last ']'
+
         # Replace dashes with underscores
         gsub(/[-]/, "_", variable)
         # Trim trailing whitespaces from variable and value
@@ -207,8 +211,8 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
         #struct_names[current_scope "_" variable ]=variable
 
         curr_idx=0
-        while (match(value,/^ *({ *[^{}\\\$#\]\[]+ *} *,? *)+ *$/, parts)) {
-            current_decl = gensub(/^ *{ *([^{}\\\$#\]\[]+) *}.*$/, "\\1", 1, value)
+        while (match(value,/^ *({ *[^{}\\\$#]+ *} *,? *)+ *$/, parts)) {
+            current_decl = gensub(/^ *{ *([^{}\\\$#]+) *}.*$/, "\\1", 1, value)
 
             # Extract variable
             struct_variable = gensub(/^ *"?([^{="]+)"? *=.*$/, "\\1", "g", current_decl)
@@ -224,27 +228,45 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
                 error_flag=1
                 next
             }
-            split(struct_value, struct_tokens, ",");
+            delete struct_tokens
+            n = split_top_level(current_decl, struct_tokens)
             for (struct_decl in struct_tokens) {
                 if (match(struct_tokens[struct_decl], /^[[:space:]]*([^=[:space:]]+)[[:space:]]*=[[:space:]]*(.*)$/, m)) {
                     var = m[1]
                     val = m[2]
-                    var=gensub(/^ *"?([^"]+)"? *$/, "\\1", "g", var)
-                    val=gensub(/^ *"?([^"]*)"? *$/, "\\1", "g", val)
-                    # Trim trailing whitespaces from variable and value
-                    gsub(/[ \t]+$/, "", var)
-                    gsub(/[ \t]+$/, "", val)
+                    var=gensub(/^ *"?([^}]+)"? *$/, "\\1", "g", var)
+                    if(match(val, " *\\[(" arr_val_rgx ")\\] *$", m2)) {
+                        arr_idx=0;
+                        split(m2[1], arr_tokens, ",");
+                        for (arr_value in arr_tokens) {
+                            m2[1] = gensub(/^ *"([^"=,\\\]]*)" *$/, "\\1", "g", arr_tokens[arr_value])
+                            arr_struct_values[current_scope "_" variable "_" curr_idx "[" var "_" arr_idx "]" ]=m2[1]
+                            if (!(current_scope in scopes)) {
+                                scopes[current_scope]++
+                            }
+                            arr_idx++
+                        }
+                        if (arr_idx > 0) {
+                            arr_struct_array_names[current_scope "_" variable "_" curr_idx "_" var ]=var
+                            arr_struct_array_lengths[current_scope "_" variable "_" curr_idx "_" var ]=arr_idx
+                        }
+                    } else {
+                        val=gensub(/^ *"?([^"]*)"? *$/, "\\1", "g", val)
+                        # Trim trailing whitespaces from variable and value
+                        gsub(/[ \t]+$/, "", var)
+                        gsub(/[ \t]+$/, "", val)
 
-                    # Check if left side contains disallowed characters
-                    if (index(var, " ") > 0 || (index(var, "#") > 0 && index(var, "\"") == 0)) {
-                        print "[LINT]    Invalid left side (contains spaces or disallowed characters):    " var "" > "/dev/stderr"
-                        error_flag=1
-                        next
+                        # Check if left side contains disallowed characters
+                        if (index(var, " ") > 0 || (index(var, "#") > 0 && index(var, "\"") == 0)) {
+                            print "[LINT]    Invalid left side (contains spaces or disallowed characters):    " var "" > "/dev/stderr"
+                            error_flag=1
+                            next
+                        }
+                        if (!(current_scope in scopes)) {
+                            scopes[current_scope]++
+                        }
+                        arr_struct_values[current_scope "_" variable "_" curr_idx "[" var "]"]=val
                     }
-                    if (!(current_scope in scopes)) {
-                        scopes[current_scope]++
-                    }
-                    arr_struct_values[current_scope "_" variable "_" curr_idx "[" var "]"]=val
                 } else {
                     print "[LEX]    Failed capture of struct_decl " struct_tokens[struct_decl] "" > "/dev/stderr"
                     error_flag=1
@@ -253,7 +275,7 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
             }
             arr_struct_names[current_scope "_" variable "_" curr_idx ]=variable
 
-            sub(/^ *{ *[^}\\\$#\]\[]+ *} *,?/,"",value)
+            sub(/^ *{ *[^}\\\$#]+ *} *,?/,"",value)
             curr_idx++
         }
     } else if ($0 ~ arr_rgx) {
@@ -355,6 +377,11 @@ function split_top_level(s, out,    i,c,buf,depth_sq,depth_cu,in_str,n) {
             for (arr_struct_value in arr_struct_values) {
                 if (index(arr_struct_value, scope "_") == 1 || (scope == "main" && index(arr_struct_value, "main_") == 1)) {
                     print "In-Arr Structvalue: " arr_struct_value ", Value: " arr_struct_values[arr_struct_value]
+                }
+            }
+            for (arr_struct_arr_name in arr_struct_array_names) {
+                if (index(arr_struct_arr_name, scope "_") == 1 || (scope == "main" && index(arr_struct_arr_name, "main_") == 1)) {
+                    print "In-Arr Struct Array: " arr_struct_arr_name ", Name: " arr_struct_array_names[arr_struct_arr_name] ", Len: " arr_struct_array_lengths[arr_struct_arr_name]
                 }
             }
             print "------------------------"

--- a/tests/arrays.stego
+++ b/tests/arrays.stego
@@ -20,3 +20,8 @@ events = [
   { name = "start", time = 07:00:00 },
   { name = "stop",  time = 18:00:00 }
 ]
+
+deep = [
+  { foo = [ 123, 124 ] },
+  { foo = [ 420, 69, 1337 ], bar = "foo" }
+]

--- a/tests/structs.stego
+++ b/tests/structs.stego
@@ -5,3 +5,4 @@ window = { width = 800, height = 600 }
 thresholds = { values = [0.1, 0.5, 0.9] }
 users      = { names = ["alice", "bob", "carol"] }
 schedule   = { days = [1979-05-27, 1979-05-28] }
+mixed = { foo = "bar", baz = [ "100", "200" ] }


### PR DESCRIPTION
### Added

- Allow structs with mixed values and arrays
- Allow arrays of structs to hold inner arrays
- Add `split_top_level()` to replace simple `split` on `,`

### Changed

- Drop explicit check for struct of only arrays
- Refactor `struct_rgx` to use `struct_rgx_val`
- Ban `<(` anywhere in a line